### PR TITLE
Fixed PHP 8.1 deprecation warnings

### DIFF
--- a/lib/OpenCloud/Common/ArrayAccess.php
+++ b/lib/OpenCloud/Common/ArrayAccess.php
@@ -17,6 +17,7 @@ class ArrayAccess implements \ArrayAccess
      * @param mixed $offset
      * @param mixed $value
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if ($offset === null) {
@@ -32,6 +33,7 @@ class ArrayAccess implements \ArrayAccess
      * @param mixed $offset
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return array_key_exists($offset, $this->elements);
@@ -42,6 +44,7 @@ class ArrayAccess implements \ArrayAccess
      *
      * @param mixed $offset
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->elements[$offset]);
@@ -53,6 +56,7 @@ class ArrayAccess implements \ArrayAccess
      * @param mixed $offset
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->offsetExists($offset) ? $this->elements[$offset] : null;

--- a/lib/OpenCloud/Common/Base.php
+++ b/lib/OpenCloud/Common/Base.php
@@ -245,7 +245,7 @@ abstract class Base
      *
      * @return $this
      */
-    public function setLogger(LoggerInterface $logger = null)
+    public function setLogger($logger = null)
     {
         $this->logger = $logger;
 

--- a/lib/OpenCloud/Common/Collection/ArrayCollection.php
+++ b/lib/OpenCloud/Common/Collection/ArrayCollection.php
@@ -43,6 +43,7 @@ abstract class ArrayCollection extends ArrayAccess implements Countable
     /**
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->elements);

--- a/lib/OpenCloud/Common/Collection/PaginatedIterator.php
+++ b/lib/OpenCloud/Common/Collection/PaginatedIterator.php
@@ -77,7 +77,7 @@ class PaginatedIterator extends ResourceIterator implements Iterator
      * @param array $data    Optional data to set initially
      * @return static
      */
-    public static function factory($parent, array $options = array(), array $data = null)
+    public static function factory($parent, array $options = array(), $data = null)
     {
         $list = new static();
 

--- a/lib/OpenCloud/Common/Collection/ResourceIterator.php
+++ b/lib/OpenCloud/Common/Collection/ResourceIterator.php
@@ -130,6 +130,7 @@ class ResourceIterator extends ArrayCollection implements Iterator
      *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return $this->offsetExists($this->position) && $this->position < $this->getOption('limit.total');
@@ -138,6 +139,7 @@ class ResourceIterator extends ArrayCollection implements Iterator
     /**
      * Increment the current pointer by 1, and also update the current marker.
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         $this->position++;
@@ -148,6 +150,7 @@ class ResourceIterator extends ArrayCollection implements Iterator
     /**
      * Reset the pointer and current marker.
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->position = 0;
@@ -156,6 +159,7 @@ class ResourceIterator extends ArrayCollection implements Iterator
     /**
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->constructResource($this->currentElement());
@@ -208,6 +212,7 @@ class ResourceIterator extends ArrayCollection implements Iterator
      *
      * @return int|mixed
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->position;

--- a/lib/OpenCloud/Common/Metadata.php
+++ b/lib/OpenCloud/Common/Metadata.php
@@ -107,6 +107,7 @@ class Metadata extends Base implements \Countable
         return $this->metadata;
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->metadata);


### PR DESCRIPTION
Fixed PHP 8.1 deprecation warnings when using the Rackspace remote storage on the UpdraftPlus plugin.

The issues are caused by PHP built-in class methods that now have return types. Extending the built-in PHP class without a matching return type triggers the deprecation warnings. https://php.watch/versions/8.1/internal-method-return-types

We need to add the `#[\ReturnTypeWillChange]` attribute to the class methods that are affected to avoid the deprecation messages but still have backward compatibility to PHP 5.